### PR TITLE
fix: dead code after unconditional return in amd_dbgapi_get_build_name

### DIFF
--- a/src/versioning.cpp
+++ b/src/versioning.cpp
@@ -35,8 +35,6 @@ amd_dbgapi_get_build_name ()
   TRACE_BEGIN ();
 
   return AMD_DBGAPI_BUILD_INFO;
-
-  TRACE_END ();
 }
 
 void AMD_DBGAPI


### PR DESCRIPTION
This PR addresses the following issue in `src/versioning.cpp`: dead code after unconditional return in amd_dbgapi_get_build_name.

## Changes
- `src/versioning.cpp`: dead code after unconditional return in amd_dbgapi_get_build_name.

## Details
```diff
--- a/src/versioning.cpp
+++ b/src/versioning.cpp
@@ -1,4 +1,2 @@
-  return AMD_DBGAPI_BUILD_INFO;
-
-  TRACE_END ();
-}
+  return AMD_DBGAPI_BUILD_INFO;
+}
```

## Tests
- `tests/test_versioning.cpp`